### PR TITLE
Upgraded to Taffy 0.5.1 with support for CSS Block, overflow and improved measure functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ pyo3 = { version = "0.20.0", features = ["abi3-py38", "extension-module"] }
 dict_derive = "0.5.0"
 log = "0.4"
 pyo3-log = ">=0.9.0, <1.0"
-taffy = ">=0.3.18, <0.4"
+taffy = ">=0.5.1, <0.6"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ NOTE: Sometimes, you may need to run `make clean html` (in `docs/` folder) to en
 
 ### Testing
 
-Install test dependencies and invoke `pytest`. Note that there are ~650 tests, the majority of which are run using Selenium with the Chrome WebDriver, and the complete test suite can take ~20 minutes to complete. Use `pytest --lf` to only run the last-failed tests.
+Install test dependencies and invoke `pytest`. Note that there are ~900 tests, the majority of which are run using Selenium with the Chrome WebDriver, and the complete test suite can take ~20 minutes to complete. Use `pytest --lf` to only run the last-failed tests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ NOTE: Sometimes, you may need to run `make clean html` (in `docs/` folder) to en
 
 ### Testing
 
-Install test dependencies and invoke `pytest`. Note that there are ~900 tests, the majority of which are run using Selenium with the Chrome WebDriver, and the complete test suite can take ~20 minutes to complete. Use `pytest --lf` to only run the last-failed tests.
+Install test dependencies and invoke `pytest`. Note that there are ~900 tests, the majority of which are run using Selenium with the Chrome WebDriver, and the complete test suite can take ~30 minutes to complete. Use `pytest --lf` to only run the last-failed tests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 [![Test results](https://gist.githubusercontent.com/mortencombat/901f1f1190ba5aff13164ede9d4c249f/raw/5aa957027330c7ea739a97ee1319226883ed0734/stretchable-tests.svg)](https://github.com/mortencombat/stretchable/actions/workflows/test.yml)
 [![Test coverage](https://gist.githubusercontent.com/mortencombat/b121474745d15f92a295a0bdd7497529/raw/c1e5ec0253129c9f25ba2ba76c79ce5557fdbad3/stretchable-coverage.svg)](https://github.com/mortencombat/stretchable/actions/workflows/test.yml)
 
-**stretchable** is a layout library for Python that enables context-agnostic layout operations using [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) and [Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Possible uses include UI layouts, page layouts for reports, complex plotting layouts, etc.
+**stretchable** is a layout library for Python that enables context-agnostic layout operations using CSS Block, [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) and [Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Possible uses include UI layouts, page layouts for reports, complex plotting layouts, etc.
 
-It implements Python bindings for [Taffy](https://github.com/dioxuslabs/taffy), an implementation of Grid/Flexbox written in [Rust](https://www.rust-lang.org/). It was originally based on [Stretch](https://vislyhq.github.io/stretch/) (hence the name), but has since migrated to use Taffy. It is multi-platform and there are distributions available for Windows, Linux and macOS.
+It implements Python bindings for [Taffy](https://github.com/dioxuslabs/taffy), an implementation of **CSS Block**, **Flexbox** and **CSS Grid** layout algorithms written in [Rust](https://www.rust-lang.org/). It was originally based on [Stretch](https://vislyhq.github.io/stretch/) (hence the name), but has since migrated to use Taffy. It is multi-platform and there are distributions available for Windows, Linux and macOS.
 
 ## Getting Started
 
 **stretchable** is a Python package [hosted on PyPI](https://pypi.org/project/stretchable/). It can be installed using [pip](https://pip.pypa.io/en/stable/):
 
 ```console
-python -m pip install attrs
+python -m pip install stretchable
 ```
 
 Building a tree of nodes and calculating the layout is as simple as:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,10 +30,20 @@ Styles
 
         Used to control node visibility and layout strategy.
 
-    .. property:: overflow
+    .. property:: overflow_x
         :type: Overflow
 
-        Controls the desired behavior when content does not fit inside the parent node.
+        Controls the desired behavior when content does not fit horizontally inside the parent node.
+
+    .. property:: overflow_y
+        :type: Overflow
+
+        Controls the desired behavior when content does not fit vertically inside the parent node.
+
+    .. property:: scrollbar_width
+        :type: float
+
+        How much space (in points) should be reserved for the scrollbars of `Overflow.SCROLL` nodes.
 
     .. property:: position
         :type: Position

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,16 +4,16 @@ hide-toc: true
 
 # stretchable
 
-**stretchable** is a layout library for Python that enables context-agnostic layout operations using [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) and [Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Possible uses include UI layouts, page layouts for reports, complex plotting layouts, etc.
+**stretchable** is a layout library for Python that enables context-agnostic layout operations using CSS Block, [CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) and [Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Possible uses include UI layouts, page layouts for reports, complex plotting layouts, etc.
 
-It implements Python bindings for [Taffy](https://github.com/dioxuslabs/taffy), an implementation of Grid/Flexbox written in [Rust](https://www.rust-lang.org/). It was originally based on [Stretch](https://vislyhq.github.io/stretch/) (hence the name), but has since migrated to use Taffy. It is multi-platform and there are distributions available for Windows, Linux and macOS.
+It implements Python bindings for [Taffy](https://github.com/dioxuslabs/taffy), an implementation of **CSS Block**, **Flexbox** and **CSS Grid** layout algorithms written in [Rust](https://www.rust-lang.org/). It was originally based on [Stretch](https://vislyhq.github.io/stretch/) (hence the name), but has since migrated to use Taffy. It is multi-platform and there are distributions available for Windows, Linux and macOS.
 
 ## Getting Started
 
 **stretchable** is a Python package [hosted on PyPI](https://pypi.org/project/stretchable/). It can be installed using [pip](https://pip.pypa.io/en/stable/):
 
 ```console
-$ python -m pip install attrs
+$ python -m pip install stretchable
 ```
 
 These next steps will help you get started:

--- a/docs/source/test.py
+++ b/docs/source/test.py
@@ -1,5 +1,0 @@
-from pathlib import Path
-
-path = Path(__file__).parents[1].resolve()
-
-print(path)

--- a/run_fixture.py
+++ b/run_fixture.py
@@ -4,9 +4,17 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 
-from demos.example import print_layout
 from stretchable.node import Edge, Node
 from tests.test_fixtures import apply_node_measure, get_layout_expected, get_xml
+
+
+def print_layout(node: Node, index: int = 0):
+    print(" " * index + f"is_visible: {node.is_visible}")
+    for box in Edge:
+        layout = node.get_box(box)
+        print(" " * index + box._name_ + ": " + str(layout))
+    for child in node:
+        print_layout(child, index=index + 2)
 
 
 def print_chrome_layout(node: WebElement, index: int = 0):
@@ -33,7 +41,7 @@ filepath = Path(
     # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/taffy/max_height_overrides_height_on_root.html"
     # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/taffy/min_height_overrides_height_on_root.html"
     # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/taffy/undefined_height_with_min_max.html"
-    "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/flex/min_width_overrides_max_width.html"
+    "/Users/kenneth/Code/Personal/stretchable/tests/fixtures/block/block_overflow_scrollbars_overridden_by_available_space.html"
 )
 
 # Get layout using taffy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -786,59 +786,6 @@ fn node_get_layout(taffy_ptr: usize, node_ptr: usize) -> PyLayout {
     layout
 }
 
-// create_exception!(
-//     taffylib,
-//     NodeMeasureError,
-//     PyException,
-//     "Raised when the `measure` method assigned to a node failed."
-// );
-
-// impl FromPyMeasure<MeasureFunc> for MeasureFunc {
-//     fn from_py(node: PyObject, measure: PyObject) -> MeasureFunc {
-//         MeasureFunc::Boxed(Box::new(
-//             move |known_dimensions: Size<Option<f32>>,
-//                   available_space: Size<AvailableSpace>|
-//                   -> Size<f32> {
-//                 // acquire lock
-//                 let size = Python::with_gil(|py| -> Vec<f32> {
-//                     // call function
-//                     let available_width: PyLength = available_space.width.into();
-//                     let available_height: PyLength = available_space.height.into();
-//                     let args = (
-//                         &node,
-//                         known_dimensions.width.unwrap_or(f32::NAN),
-//                         known_dimensions.height.unwrap_or(f32::NAN),
-//                         available_width,
-//                         available_height,
-//                     );
-//                     let result = measure.call1(py, args);
-
-//                     match result {
-//                         Ok(result) => result.extract(py).unwrap(),
-//                         Err(err) => {
-//                             let traceback = match err.traceback(py) {
-//                                 Some(value) => match value.format() {
-//                                     Ok(tb) => format!("{}\n", tb),
-//                                     Err(_) => String::new(),
-//                                 },
-//                                 None => String::new(),
-//                             };
-//                             error!(target: "stretchable.taffylib", "Error in node `measure` (used `NAN, NAN` in place):\n{}{}", traceback, err);
-//                             vec![f32::NAN, f32::NAN]
-//                         }
-//                     }
-//                 });
-
-//                 // return result
-//                 Size {
-//                     width: size[0],
-//                     height: size[1],
-//                 }
-//             },
-//         ))
-//     }
-// }
-
 // MODULE
 
 // for pyo3-pack, name must match module.
@@ -870,7 +817,6 @@ fn taffylib(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(node_set_context))?;
     m.add_wrapped(wrap_pyfunction!(node_compute_layout))?;
     m.add_wrapped(wrap_pyfunction!(node_compute_layout_with_measure))?;
-    // m.add("NodeMeasureError", py.get_type::<NodeMeasureError>())?;
 
     Ok(())
 }

--- a/src/stretchable/node.py
+++ b/src/stretchable/node.py
@@ -62,49 +62,6 @@ def _measure_callback(
     )
 
 
-"""
-NODE MEASURE
-
-CURRENT PROCESS
----------------
-
-1) A specific measure function Callable[[SizePoints, SizeAvailableSpace], SizePoints] is stored on the node
-   Any additional information (such as text/font, image dimensions, etc.) needed by the function must be stored in the function
-
-2) This function is invoked during the layout computation process
-
-FUTURE/SUGGESTED PROCESS
-------------------------
-
-1) A global measure function is used when computing layout
-
-2) Each node can be provided with NodeContext, which is passed to the global measure function
-
-NodeContext in Python must be converted to Rust, to be able to be passed in to
-Taffy. This may complicate user-defined contexts?
-
-Consider instead in NodeContext passing the ptr, and then use the ptr to
-identify the Python node instance and pass that to the global measure function.
-Any necessary context could then be stored on the node.
-
-Another option would be to stick with node-specific measure functions, but use
-the procedure described above to retrieve the node instance, and then invoke the
-node measure function with the node (self) available as context.
-
-TODO:
-    - Nodes should be created with context if a measure function is provided,
-      and the context should be a unique identifier that can be used to identify and retrieve the node instance
-      Don't use NodeContext, instead use NodeId ?
-    - A global measure function should be created, which:
-        1) Retrieves the node instance from node context (identifier)
-        2) If node has a measure function assigned, invoke it and return the result
-
-
-When measure property is changed on a node, set NodeContext in taffy, and keep a dict[ptr, node] of all nodes with measure properties set
-
-"""
-
-
 class Edge(StrEnum):
     """Describes which edge of a node a given :py:obj:`Box` corresponds to. See the :doc:`glossary` for a description of the box model and the different boxes."""
 

--- a/src/stretchable/style/core.py
+++ b/src/stretchable/style/core.py
@@ -86,6 +86,17 @@ class Style:
         validator=[validators.instance_of(Display)],
     )
 
+    # Overflow
+    overflow_x: Overflow = field(
+        default=Overflow.VISIBLE,
+        validator=[validators.instance_of(Overflow)],
+    )
+    overflow_y: Overflow = field(
+        default=Overflow.VISIBLE,
+        validator=[validators.instance_of(Overflow)],
+    )
+    scrollbar_width: float = 0.0
+
     # Position
     position: Position = field(
         default=Position.RELATIVE,
@@ -194,6 +205,10 @@ class Style:
         return (
             # Layout mode
             self.display,
+            # Overflow
+            self.overflow_x,
+            self.overflow_y,
+            self.scrollbar_width,
             # Position
             self.position,
             self.inset.to_dict(),
@@ -238,7 +253,7 @@ class Style:
         logger.debug("style_create() -> %s" % self.__ptr)
 
     def __del__(self) -> None:
-        if self.__ptr is None:
+        if not hasattr(self, "_Style__ptr") or self.__ptr is None:
             return
         taffylib.style_drop(self.__ptr)
         logger.debug("style_drop(ptr: %s)", self.__ptr)
@@ -371,6 +386,8 @@ class Style:
             match prop:
                 case "display":
                     return Display
+                case "overflow":
+                    return Overflow
                 case "justify-content":
                     return JustifyContent
                 case "justify-items":
@@ -385,8 +402,6 @@ class Style:
                     return AlignContent
                 case "flex-direction":
                     return FlexDirection
-                case "overflow":
-                    return Overflow
                 case "position":
                     return Position
                 case "flex-wrap":
@@ -422,6 +437,37 @@ class Style:
                 flex_shrink=values[1] if n >= 2 else 1,
                 flex_basis=values[2] if n >= 3 else 0,
             )
+
+        def to_overflow() -> dict[str, Any]:
+            values = [None, None]
+
+            # First look for 'overflow' which can be a single value (overflow-x == overflow_y) or two values
+            if "overflow" in keys:
+                value = props["overflow"].strip()
+                values = value.split(" ")
+                n = len(values)
+                if n == 1:
+                    values = values * 2
+                elif n > 2:
+                    logger.warning(
+                        f"Style property overflow: {value} could not be parsed"
+                    )
+                keys.remove("overflow")
+
+            # Then look for 'overflow-x' and 'overflow-y' (eg. these will override if overflow is also present)
+            for i, prop in enumerate(("overflow-x", "overflow-y")):
+                if prop not in keys:
+                    continue
+                values[i] = props[prop]
+                keys.remove(prop)
+
+            # Translate str values into corresponding enums and insert into dictionary
+            r = dict()
+            for prop, value in zip(("overflow_x", "overflow_y"), values):
+                if not value:
+                    continue
+                r[prop] = Overflow[value.strip().upper()]
+            return r
 
         def to_grid() -> dict[str, Any]:
             def split_parts(value: str) -> list[str]:
@@ -538,7 +584,6 @@ class Style:
             "display",
             "flex-direction",
             "flex-wrap",
-            "overflow",
             "align-items",
             "align-self",
             "align-content",
@@ -554,13 +599,24 @@ class Style:
 
         # float and Dim entries:
         #   flex-basis, flex-grow, flex-shrink, aspect-ratio
-        for prop in ("flex-basis", "flex-grow", "flex-shrink", "aspect-ratio"):
+        for prop in (
+            "flex-basis",
+            "flex-grow",
+            "flex-shrink",
+            "aspect-ratio",
+            "scrollbar-width",
+        ):
             v = to_float(prop)
             if v is not None:
                 args[prop.replace("-", "_")] = v
 
         # Special handling for flex property
         v = to_flex()
+        if v:
+            args.update(**v)
+
+        # Special handling for overflow/overflow-x/overflow-y properties
+        v = to_overflow()
         if v:
             args.update(**v)
 

--- a/src/stretchable/style/core.py
+++ b/src/stretchable/style/core.py
@@ -414,7 +414,9 @@ class Style:
             if prop in keys:
                 keys.remove(prop)
                 enum = prop_to_enum(prop)
-                return enum[props[prop].strip().upper().replace("-", "_")]
+                return enum[
+                    props[prop].strip().upper().replace("-", "_").replace(" ", "_")
+                ]
 
         def to_float(prop: str) -> float:
             if prop in keys:

--- a/src/stretchable/style/props.py
+++ b/src/stretchable/style/props.py
@@ -50,6 +50,7 @@ class Display(IntEnum):
     NONE = 0
     FLEX = 1
     GRID = 2
+    BLOCK = 3
 
 
 class Overflow(IntEnum):
@@ -61,6 +62,7 @@ class Overflow(IntEnum):
     VISIBLE = 0
     HIDDEN = 1
     SCROLL = 2
+    CLIP = 3
 
 
 class Position(IntEnum):
@@ -514,9 +516,11 @@ class GridTrackSizing:
             )
 
         return dict(
-            repetition=self.repetition
-            if self.repetition != GridTrackRepetition.COUNT
-            else self.count,
+            repetition=(
+                self.repetition
+                if self.repetition != GridTrackRepetition.COUNT
+                else self.count
+            ),
             single=None,
             repeat=[t.to_dict() for t in self.tracks],
         )

--- a/tests/fixtures/block/block_absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_aspect_ratio_overrides_height_of_full_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; top: 5%; bottom: 5%; left: 5%; right: 5%; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_height.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; top: 5%; left: 5%; width: 50%; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_height_from_inset.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_height_from_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; top: 5%; left: 10%; right: 10%; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_max_height.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_max_height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; max-width: 50px; aspect-ratio: 3;">HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH</div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_max_width.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_max_width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; max-height: 50px; aspect-ratio: 0.5;">HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH&ZeroWidthSpace;HHHH</div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_min_height.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_min_height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; min-width: 50px; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_min_width.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_min_width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; min-height: 50px; aspect-ratio: 0.5;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_width.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; top: 5%; left: 5%; height: 20%; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_fill_width_from_inset.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_fill_width_from_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; top: 30%; bottom: 50%; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_height_overrides_inset.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_height_overrides_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; top: 30%; bottom: 50%; height: 10%; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_aspect_ratio_width_overrides_inset.html
+++ b/tests/fixtures/block/block_absolute_aspect_ratio_width_overrides_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 400px; height: 300px;">
+  <div style="position: absolute; top: 5%; left: 10%; right: 10%; width: 40%; aspect-ratio: 3;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_child_with_margin_x.html
+++ b/tests/fixtures/block/block_absolute_child_with_margin_x.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 20px; height: 37px;">
+  <div style="width: 9px; height: 9px; position: absolute; margin-left: 7px;"></div>
+  <div style="width: 9px; height: 9px; position: absolute; margin-right: 7px;"></div>
+  <div style="width: 9px; height: 9px; position: absolute; margin-left: 10px; margin-right: 5px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_child_with_margin_y.html
+++ b/tests/fixtures/block/block_absolute_child_with_margin_y.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 20px; height: 37px;">
+  <div style="width: 9px; height: 9px; position: absolute; margin-top: 7px;"></div>
+  <div style="width: 9px; height: 9px; position: absolute; margin-bottom: 7px;"></div>
+  <div style="width: 9px; height: 9px; position: absolute; margin-top: 10px; margin-bottom: 5px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_child_with_max_height.html
+++ b/tests/fixtures/block/block_absolute_child_with_max_height.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 200px;">
+  <div style="display: block; position: absolute; bottom: 20px; max-height: 100px;">
+    <div style="display: block; width: 100px; height: 150px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_child_order.html
+++ b/tests/fixtures/block/block_absolute_layout_child_order.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 110px; align-items: center; justify-content: center;">
+  <div style="display: block; width: 60px; height: 40px;"></div>
+  <div style="display: block; position: absolute; width: 60px; height: 40px;"></div>
+  <div style="display: block; width: 60px; height: 40px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_no_size.html
+++ b/tests/fixtures/block/block_absolute_layout_no_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px;">
+  <div style="position: absolute;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_percentage_bottom_based_on_parent_height.html
+++ b/tests/fixtures/block/block_absolute_layout_percentage_bottom_based_on_parent_height.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 200px;">
+  <div style="display: block; position: absolute; top: 50%; width: 10px; height: 10px;"></div>
+  <div style="display: block; position: absolute; bottom: 50%; width: 10px; height: 10px;"></div>
+  <div style="display: block; position: absolute; top: 10%; width: 10px; bottom: 10%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_percentage_height.html
+++ b/tests/fixtures/block/block_absolute_layout_percentage_height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 100px;">
+  <div style="width: 10px; height: 50%; position: absolute; left: 10px; top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_row_width_height_end_bottom.html
+++ b/tests/fixtures/block/block_absolute_layout_row_width_height_end_bottom.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="width: 10px; height: 10px; position: absolute; right: 10px; bottom: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_start_top_end_bottom.html
+++ b/tests/fixtures/block/block_absolute_layout_start_top_end_bottom.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; left: 10px; top: 10px; right: 10px; bottom: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_width_height_end_bottom.html
+++ b/tests/fixtures/block/block_absolute_layout_width_height_end_bottom.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; width: 10px; height: 10px; position: absolute; right: 10px; bottom: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_width_height_start_top.html
+++ b/tests/fixtures/block/block_absolute_layout_width_height_start_top.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; width: 10px; height: 10px; position: absolute; left: 10px; top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_width_height_start_top_end_bottom.html
+++ b/tests/fixtures/block/block_absolute_layout_width_height_start_top_end_bottom.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; width: 10px; height: 10px; position: absolute; left: 10px; top: 10px; right: 10px; bottom: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_layout_within_border.html
+++ b/tests/fixtures/block/block_absolute_layout_within_border.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px; border-width: 10px; padding: 10px;">
+  <div style="display: block; position: absolute; width: 50px; height: 50px; left: 0px; top: 0px;"></div>
+  <div style="display: block; position: absolute; width: 50px; height: 50px; right: 0px; bottom: 0px;"></div>
+  <div style="display: block; position: absolute; width: 50px; height: 50px; left: 0px; top: 0px; margin: 10px;"></div>
+  <div style="display: block; position: absolute; width: 50px; height: 50px; right: 0px; bottom: 0px; margin: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_bottom_and_top_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_bottom_and_top_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-top: auto; margin-bottom: auto; top: 10px; bottom: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_bottom_and_top_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_bottom_and_top_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-top: auto; margin-bottom: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_bottom_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_bottom_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-bottom: auto; top: 10px; bottom: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_bottom_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_bottom_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-bottom: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_and_right_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_and_right_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-left: auto; margin-right: auto; left: 10px; right: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_and_right_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_and_right_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-left: auto; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_child_bigger_than_parent_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_child_bigger_than_parent_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="position: absolute; width: 72px; height: 72px; margin-left: auto; left: 10px; right: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_child_bigger_than_parent_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_child_bigger_than_parent_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="position: absolute; width: 72px; height: 72px; margin-left: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_fix_right_child_bigger_than_parent_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_fix_right_child_bigger_than_parent_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="position: absolute; width: 72px; height: 72px; margin-left: auto; margin-right: 10px; left: 10px; right: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_fix_right_child_bigger_than_parent_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_fix_right_child_bigger_than_parent_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="position: absolute; width: 72px; height: 72px; margin-left: auto; margin-right: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_right_child_bigger_than_parent_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_right_child_bigger_than_parent_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="position: absolute; width: 72px; height: 72px; margin-left: auto; margin-right: auto; left: 10px; right: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_right_child_bigger_than_parent_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_right_child_bigger_than_parent_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="position: absolute; width: 72px; height: 72px; margin-left: auto; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-left: auto; left: 10px; right: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_left_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_left_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-left: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_multiple_children_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_multiple_children_with_inset.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; flex-direction: row; align-items: center;">
+  <div style="position: absolute; width: 100px; height: 50px; margin-right: auto; left: 10px; right: 20px;"></div>
+  <div style="position: absolute; width: 50px; height: 50px; margin-right: auto; left: 20px; right: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_multiple_children_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_multiple_children_without_inset.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; flex-direction: row; align-items: center;">
+  <div style="position: absolute; width: 100px; height: 50px; margin-right: auto;"></div>
+  <div style="position: absolute; width: 50px; height: 50px; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_right_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_right_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-right: auto; left: 10px; right: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_right_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_right_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_top_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_top_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-top: auto; top: 20px; bottom: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_auto_top_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_auto_top_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="position: absolute; width: 50px; height: 50px; margin-top: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_bottom_left_with_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_bottom_left_with_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; height: 10px; width: 10px; margin-bottom: 10px; margin-left: 10px; top: 10px; bottom: 20px; left: 20px; right: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_margin_bottom_left_without_inset.html
+++ b/tests/fixtures/block/block_absolute_margin_bottom_left_without_inset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; height: 10px; width: 10px; margin-bottom: 10px; margin-left: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_minmax_bottom_right_max.html
+++ b/tests/fixtures/block/block_absolute_minmax_bottom_right_max.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; right: 10px; bottom: 10px; width: 100px; height: 100px; max-width: 40px; max-height: 30px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_minmax_bottom_right_min_max.html
+++ b/tests/fixtures/block/block_absolute_minmax_bottom_right_min_max.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; right: 10px; bottom: 10px; max-width: 40px; min-width: 50px; max-height: 30px; min-height: 60px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_minmax_bottom_right_min_max_preferred.html
+++ b/tests/fixtures/block/block_absolute_minmax_bottom_right_min_max_preferred.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; right: 10px; bottom: 10px; max-width: 40px; min-width: 50px; max-height: 30px; min-height: 60px; width: 200px; height: 200px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_minmax_top_left_bottom_right_max.html
+++ b/tests/fixtures/block/block_absolute_minmax_top_left_bottom_right_max.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; left: 10px; top: 10px; right: 10px; bottom: 10px; max-width: 40px; max-height: 30px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_minmax_top_left_bottom_right_min_max.html
+++ b/tests/fixtures/block/block_absolute_minmax_top_left_bottom_right_min_max.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: block; position: absolute; left: 10px; top: 10px; right: 10px; bottom: 10px; max-width: 40px; min-width: 50px; max-height: 30px; min-height: 60px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_no_styles.html
+++ b/tests/fixtures/block/block_absolute_no_styles.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; height: 10px; width: 50px;"></div>
+  <div style="display: block; position: absolute;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_padding_border_overrides_max_size.html
+++ b/tests/fixtures/block/block_absolute_padding_border_overrides_max_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; position: absolute; max-width: 12px; max-height: 12px; padding: 2px 4px 6px 8px; border-width: 1px 3px 5px 7px; border-style: solid; border-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_absolute_padding_border_overrides_size.html
+++ b/tests/fixtures/block/block_absolute_padding_border_overrides_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; position: absolute; width: 12px; height: 12px; padding: 2px 4px 6px 8px; border-width: 1px 3px 5px 7px; border-style: solid; border-color: red;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_align_baseline_child.html
+++ b/tests/fixtures/block/block_align_baseline_child.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="flex-direction: column; width: 100px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="display: block; width: 50px; height: 50px;"></div>
+  <div style="display: block; width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_align_baseline_child_margin.html
+++ b/tests/fixtures/block/block_align_baseline_child_margin.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="display: block; width: 50px; height: 50px; margin: 5px;"></div>
+  <div style="display: block; width: 50px; height: 20px;">
+    <div style="width: 50px; height: 10px; margin: 5px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_align_baseline_child_margin_percent.html
+++ b/tests/fixtures/block/block_align_baseline_child_margin_percent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="display: block; width: 50px; height: 50px; margin: 5%;"></div>
+  <div style="display: block; width: 50px; height: 20px;">
+    <div style="display: block; width: 50px; height: 10px; margin: 1%;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_align_baseline_child_padding.html
+++ b/tests/fixtures/block/block_align_baseline_child_padding.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; padding: 5px; flex-direction: row; align-items: baseline;">
+  <div style="display: block; width: 50px; height: 50px;"></div>
+  <div style="display: block; width: 50px; height: 20px; padding: 5px;">
+    <div style="display: block; width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_align_baseline_child_top.html
+++ b/tests/fixtures/block/block_align_baseline_child_top.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="display: block; width: 50px; height: 50px; top: 10px;"></div>
+  <div style="display: block; width: 50px; height: 20px;">
+    <div style="display: block; width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_align_baseline_child_top2.html
+++ b/tests/fixtures/block/block_align_baseline_child_top2.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="display: block; width: 50px; height: 50px;"></div>
+  <div style="display: block; width: 50px; height: 20px; top: 5px;">
+    <div style="display: block; width: 50px; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_align_baseline_double_nested_child.html
+++ b/tests/fixtures/block/block_align_baseline_double_nested_child.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="width: 100px; height: 100px; flex-direction: row; align-items: baseline;">
+  <div style="display: block; width: 50px; height: 50px;">
+    <div style="display: block; width: 50px; height: 20px;"></div>
+  </div>
+  <div style="display: block; width: 50px; height: 20px;">
+    <div style="display: block; width: 50px; height: 15px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_aspect_ratio_fill_height.html
+++ b/tests/fixtures/block/block_aspect_ratio_fill_height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px;">
+  <div style="display: block; width: 40px; aspect-ratio: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_aspect_ratio_fill_max_height.html
+++ b/tests/fixtures/block/block_aspect_ratio_fill_max_height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px;">
+  <div style="display: block; max-width: 40px; aspect-ratio: 2;">HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_aspect_ratio_fill_max_width.html
+++ b/tests/fixtures/block/block_aspect_ratio_fill_max_width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px;">
+  <div style="display: block; max-height: 20px; aspect-ratio: 2;">HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_aspect_ratio_fill_min_height.html
+++ b/tests/fixtures/block/block_aspect_ratio_fill_min_height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px;">
+  <div style="display: block; min-width: 40px; aspect-ratio: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_aspect_ratio_fill_min_width.html
+++ b/tests/fixtures/block/block_aspect_ratio_fill_min_width.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px;">
+  <div style="display: block; min-height: 40px; aspect-ratio: 2;">
+    
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_aspect_ratio_fill_width.html
+++ b/tests/fixtures/block/block_aspect_ratio_fill_width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 100px; width: 100px;">
+  <div style="display: block; height: 40px; aspect-ratio: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_basic.html
+++ b/tests/fixtures/block/block_basic.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_border_fixed_size.html
+++ b/tests/fixtures/block/block_border_fixed_size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px; border-width: 2px 4px 6px 8px;">
+  <div style="height: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_border_intrinsic_size.html
+++ b/tests/fixtures/block/block_border_intrinsic_size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; border-width: 2px 4px 6px 8px;">
+  <div style="height: 10px; width: 50px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_border_percentage_fixed_size.html
+++ b/tests/fixtures/block/block_border_percentage_fixed_size.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px;">
+  <div style="display: block; border-width: 1% 2% 3% 4%;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_border_percentage_intrinsic_size.html
+++ b/tests/fixtures/block/block_border_percentage_intrinsic_size.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; border-width: 1% 2% 3% 4%;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_display_none.html
+++ b/tests/fixtures/block/block_display_none.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px;"></div>
+  <div style="display: none; height: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_display_none_with_child.html
+++ b/tests/fixtures/block/block_display_none_with_child.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="height: 10px;"></div>
+  <div style="display: none;">
+    <div style="height: 10px; width: 20px;"></div>
+  </div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_display_none_with_inset.html
+++ b/tests/fixtures/block/block_display_none_with_inset.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="height: 10px;"></div>
+  <div style="height: 10px; display: none; top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_display_none_with_margin.html
+++ b/tests/fixtures/block/block_display_none_with_margin.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="width: 20px; height: 20px; display: none; margin: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_display_none_with_position_absolute.html
+++ b/tests/fixtures/block/block_display_none_with_position_absolute.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="display: none; position: absolute; width: 100px; height: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_inset_fixed.html
+++ b/tests/fixtures/block/block_inset_fixed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; top: 4px; left: 2px;"></div>
+  <div style="height: 10px; right: 6px; bottom: 8px;"></div>
+  <div style="height: 10px; left: 2px; top: 4px; right: 6px; bottom: 8px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_inset_percentage.html
+++ b/tests/fixtures/block/block_inset_percentage.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; top: 4%; left: 2%;"></div>
+  <div style="height: 10px; right: 6%; bottom: 8%;"></div>
+  <div style="height: 10px; left: 2%; top: 4%; right: 6%; bottom: 8%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_intrinsic_width.html
+++ b/tests/fixtures/block/block_intrinsic_width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; width: 50px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_item_max_width.html
+++ b/tests/fixtures/block/block_item_max_width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="max-width: 100px; height: 50px;"></div>
+  <div style="max-width: 300px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_item_min_width_overrides_max_width.html
+++ b/tests/fixtures/block/block_item_min_width_overrides_max_width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 100px; height: 100px;">
+  <div style="min-width: 200px; max-width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_bottom.html
+++ b/tests/fixtures/block/block_margin_auto_bottom.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="width: 50px; height: 50px; margin-bottom: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_bottom_and_top.html
+++ b/tests/fixtures/block/block_margin_auto_bottom_and_top.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="width: 50px; height: 50px; margin-top: auto; margin-bottom: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_left.html
+++ b/tests/fixtures/block/block_margin_auto_left.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="width: 50px; height: 50px; margin-left: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_left_and_right.html
+++ b/tests/fixtures/block/block_margin_auto_left_and_right.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="width: 50px; height: 50px; margin-left: auto; margin-right: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_left_and_right_with_auto_width.html
+++ b/tests/fixtures/block/block_margin_auto_left_and_right_with_auto_width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px;">
+  <div style="width: auto; max-width: 100px; height: 50px; margin-left: auto; margin-right: auto;">
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_left_child_bigger_than_parent.html
+++ b/tests/fixtures/block/block_margin_auto_left_child_bigger_than_parent.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="width: 72px; height: 72px; margin-left: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_left_fix_right_child_bigger_than_parent.html
+++ b/tests/fixtures/block/block_margin_auto_left_fix_right_child_bigger_than_parent.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="width: 72px; height: 72px; margin-left: auto; margin-right: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_left_right_child_bigger_than_parent.html
+++ b/tests/fixtures/block/block_margin_auto_left_right_child_bigger_than_parent.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; height: 52px; width: 52px;">
+  <div style="width: 72px; height: 72px; margin-left: auto; margin-right: auto;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_multiple_children.html
+++ b/tests/fixtures/block/block_margin_auto_multiple_children.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; flex-direction: row; align-items: center;">
+  <div style="width: 100px; height: 50px; margin-right: auto;"></div>
+  <div style="width: 50px; height: 50px; margin-right: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_right.html
+++ b/tests/fixtures/block/block_margin_auto_right.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="width: 50px; height: 50px; margin-right: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_auto_top.html
+++ b/tests/fixtures/block/block_margin_auto_top.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px; height: 200px; align-items: center;">
+  <div style="width: 50px; height: 50px; margin-top: auto;"></div>
+  <div style="width: 50px; height: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_fixed_auto_bottom.html
+++ b/tests/fixtures/block/block_margin_x_fixed_auto_bottom.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; width: 20px; margin-bottom: auto;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_fixed_auto_left.html
+++ b/tests/fixtures/block/block_margin_x_fixed_auto_left.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; width: 20px; margin-left: auto;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_fixed_auto_left_and_right.html
+++ b/tests/fixtures/block/block_margin_x_fixed_auto_left_and_right.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; width: 20px; margin-left: auto; margin-right: auto;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_fixed_auto_right.html
+++ b/tests/fixtures/block/block_margin_x_fixed_auto_right.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; width: 20px; margin-right: auto;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_fixed_auto_top.html
+++ b/tests/fixtures/block/block_margin_x_fixed_auto_top.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; width: 20px; margin-top: auto;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_fixed_size_negative.html
+++ b/tests/fixtures/block/block_margin_x_fixed_size_negative.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-left: -10px; margin-right: -5px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_fixed_size_positive.html
+++ b/tests/fixtures/block/block_margin_x_fixed_size_positive.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-left: 10px; margin-right: 5px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_intrinsic_size_negative.html
+++ b/tests/fixtures/block/block_margin_x_intrinsic_size_negative.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; margin-left: -10px; margin-right: -5px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_intrinsic_size_positive.html
+++ b/tests/fixtures/block/block_margin_x_intrinsic_size_positive.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; margin-left: 10px; margin-right: 5px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_percentage_fixed_size_negative.html
+++ b/tests/fixtures/block/block_margin_x_percentage_fixed_size_negative.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-left: -20%; margin-right: -10%;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_percentage_fixed_size_positive.html
+++ b/tests/fixtures/block/block_margin_x_percentage_fixed_size_positive.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-left: 20%; margin-right: 10%;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_other_negative.html
+++ b/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_other_negative.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; margin-left: -20%; margin-right: -10%;"></div>
+  <div style="height: 10px; width: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_other_positive.html
+++ b/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_other_positive.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; margin-left: 20%; margin-right: 10%;"></div>
+  <div style="height: 10px; width: 100px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_self_negative.html
+++ b/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_self_negative.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; width: 100px; margin-left: -20%; margin-right: -10%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_self_positive.html
+++ b/tests/fixtures/block/block_margin_x_percentage_intrinsic_size_self_positive.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; width: 100px; margin-left: 20%; margin-right: 10%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_complex.html
+++ b/tests/fixtures/block/block_margin_y_collapse_complex.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;">
+    <div style="height: 10px; margin-top: -5px; margin-bottom: -5px;"></div>
+    <div style="height: 10px; margin-top: 7px; margin-bottom: 3px;"></div>
+    <div style="height: 10px; margin-top: -6px; margin-bottom: 9px;"></div>
+  </div>
+  <div style="height: 10px; margin-top: -5px; margin-bottom: -5px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_aspect_ratio.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_aspect_ratio.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; aspect-ratio: 2;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_border_bottom.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_border_bottom.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; border-width-bottom: 1px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_border_top.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_border_top.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; border-width-top: 1px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_height.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_height.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; height: 1px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_line_box.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_line_box.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px;">HH</div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_line_box_with_height_zero.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_line_box_with_height_zero.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; height: 0px;">HH</div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_line_box_with_max_height_zero.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_line_box_with_max_height_zero.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; max-height: 0px;">HH</div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_min_height.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_min_height.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; min-height: 1px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_x_hidden.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_x_hidden.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; overflow-x: hidden;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_x_scroll.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_x_scroll.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; overflow-x: scroll;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_y_hidden.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_y_hidden.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; overflow-y: hidden;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_y_scroll.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_overflow_y_scroll.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; overflow-y: scroll;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_padding_bottom.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_padding_bottom.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; padding-bottom: 1px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_padding_top.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_blocked_by_padding_top.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px; padding-top: 1px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_negative.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_negative.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: -5px;"></div>
+  <div style="display: block; margin-top: -7px; margin-bottom: -3px;"></div>
+  <div style="display: block; height: 10px; margin-top: -2px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_positive.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_positive.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_positive_and_negative.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_positive_and_negative.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: -10px;"></div>
+  <div style="display: block; margin-top: 5px; margin-bottom: -4px;"></div>
+  <div style="display: block; height: 10px; margin-top: 7px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_collapse_through_with_absolute_child.html
+++ b/tests/fixtures/block/block_margin_y_collapse_through_with_absolute_child.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; margin-top: 10px; margin-bottom: 10px;"><div style="position: absolute;">HH</div></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_border_top.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_border_top.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; border-width-top: 1px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_x_hidden.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_x_hidden.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; overflow-x: hidden;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_x_scroll.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_x_scroll.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; overflow-x: scroll;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_y_hidden.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_y_hidden.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; overflow-y: hidden;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_y_scroll.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_overflow_y_scroll.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; overflow-y: scroll;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_padding_top.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_blocked_by_padding_top.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; padding-top: 1px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_negative_equal.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_negative_equal.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: -10px;">
+    <div style="display: block; margin-top: -10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_negative_parent_larger.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_negative_parent_larger.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: -10px;">
+    <div style="display: block; margin-top: -5px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_negative_parent_smaller.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_negative_parent_smaller.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: -5px;">
+    <div style="display: block; margin-top: -10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_not_blocked_by_border_bottom.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_not_blocked_by_border_bottom.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; border-width-bottom: 1px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_not_blocked_by_padding_bottom.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_not_blocked_by_padding_bottom.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px; padding-bottom: 1px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_positive_and_negative.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_positive_and_negative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: -10px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+  <div style="display: block; margin-top: -10px;">
+    <div style="display: block; margin-top: 5px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+  <div style="display: block; margin-top: -5px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_positive_equal.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_positive_equal.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_positive_parent_larger.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_positive_parent_larger.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px;">
+    <div style="display: block; margin-top: 5px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_child_collapse_positive_parent_smaller.html
+++ b/tests/fixtures/block/block_margin_y_first_child_collapse_positive_parent_smaller.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 5px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_granchild_collapse_positive_and_negative.html
+++ b/tests/fixtures/block/block_margin_y_first_granchild_collapse_positive_and_negative.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: -10px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="display: block; margin-top: -10px;">
+        <div style="height: 10px;"></div>
+      </div>
+    </div>
+  </div>
+  <div style="display: block; margin-top: -10px;">
+    <div style="display: block; margin-top: 5px;">
+      <div style="display: block; margin-top: -2px;">
+        <div style="height: 10px;"></div>
+      </div>
+    </div>
+  </div>
+  <div style="display: block; margin-top: -10px;">
+    <div style="display: block; margin-top: 5px;">
+      <div style="display: block; margin-top: 15px;">
+        <div style="height: 10px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_first_granchild_collapse_positive_equal.html
+++ b/tests/fixtures/block/block_margin_y_first_granchild_collapse_positive_equal.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-top: 10px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="display: block; margin-top: 10px;">
+        <div style="height: 10px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_border_bottom.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_border_bottom.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; border-width-bottom: 1px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_x_hidden.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_x_hidden.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; overflow-x: hidden;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_x_scroll.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_x_scroll.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; overflow-x: scroll;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_y_hidden.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_y_hidden.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; overflow-y: hidden;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_y_scroll.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_overflow_y_scroll.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; overflow-y: scroll;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_padding_bottom.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_blocked_by_padding_bottom.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; padding-bottom: 1px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_negative_equal.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_negative_equal.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: -10px;">
+    <div style="display: block; margin-bottom: -10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_negative_parent_larger.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_negative_parent_larger.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: -10px;">
+    <div style="display: block; margin-bottom: -5px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_negative_parent_smaller.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_negative_parent_smaller.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: -5px;">
+    <div style="display: block; margin-bottom: -10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_not_blocked_by_border_top.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_not_blocked_by_border_top.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; border-width-top: 1px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_not_blocked_by_padding_top.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_not_blocked_by_padding_top.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px; padding-top: 1px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_positive_and_negative.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_positive_and_negative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: -10px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+  <div style="display: block; margin-bottom: -10px;">
+    <div style="display: block; margin-bottom: 5px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+  <div style="display: block; margin-bottom: -5px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_positive_equal.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_positive_equal.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_positive_parent_larger.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_positive_parent_larger.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px;">
+    <div style="display: block; margin-bottom: 5px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_child_collapse_positive_parent_smaller.html
+++ b/tests/fixtures/block/block_margin_y_last_child_collapse_positive_parent_smaller.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 5px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_last_granchild_collapse_positive_equal.html
+++ b/tests/fixtures/block/block_margin_y_last_granchild_collapse_positive_equal.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; margin-bottom: 10px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="display: block; margin-bottom: 10px;">
+        <div style="height: 10px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_sibling_collapse_negative.html
+++ b/tests/fixtures/block/block_margin_y_sibling_collapse_negative.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+  <div style="height: 10px; margin-top: -5px; margin-bottom: -5px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_sibling_collapse_negative_percentage.html
+++ b/tests/fixtures/block/block_margin_y_sibling_collapse_negative_percentage.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: -10%; margin-bottom: -10%;"></div>
+  <div style="height: 10px; margin-top: -10%; margin-bottom: -10%;"></div>
+  <div style="height: 10px; margin-top: -5%; margin-bottom: -5%;"></div>
+  <div style="height: 10px; margin-top: -10%; margin-bottom: -10%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_sibling_collapse_positive.html
+++ b/tests/fixtures/block/block_margin_y_sibling_collapse_positive.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: 10px; margin-bottom: 10px;"></div>
+  <div style="height: 10px; margin-top: 10px; margin-bottom: 10px;"></div>
+  <div style="height: 10px; margin-top: 5px; margin-bottom: 5px;"></div>
+  <div style="height: 10px; margin-top: 10px; margin-bottom: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_sibling_collapse_positive_and_negative.html
+++ b/tests/fixtures/block/block_margin_y_sibling_collapse_positive_and_negative.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: 10px; margin-bottom: 10px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: 10px;"></div>
+  <div style="height: 10px; margin-top: -5px; margin-bottom: 5px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+  <div style="height: 10px; margin-top: 10px; margin-bottom: -10px;"></div>
+  <div style="height: 10px; margin-top: 5px; margin-bottom: -5px;"></div>
+  <div style="height: 10px; margin-top: 10px; margin-bottom: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_sibling_collapse_positive_and_negative_percentage.html
+++ b/tests/fixtures/block/block_margin_y_sibling_collapse_positive_and_negative_percentage.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: 10%; margin-bottom: 10%;"></div>
+  <div style="height: 10px; margin-top: -10%; margin-bottom: 10%;"></div>
+  <div style="height: 10px; margin-top: -5%; margin-bottom: 5%;"></div>
+  <div style="height: 10px; margin-top: -10%; margin-bottom: -10%;"></div>
+  <div style="height: 10px; margin-top: 10%; margin-bottom: -10%;"></div>
+  <div style="height: 10px; margin-top: 5%; margin-bottom: -5%;"></div>
+  <div style="height: 10px; margin-top: 10%; margin-bottom: 10%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_sibling_collapse_positive_percentage.html
+++ b/tests/fixtures/block/block_margin_y_sibling_collapse_positive_percentage.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: 10%; margin-bottom: 10%;"></div>
+  <div style="height: 10px; margin-top: 10%; margin-bottom: 10%;"></div>
+  <div style="height: 10px; margin-top: 5%; margin-bottom: 5%;"></div>
+  <div style="height: 10px; margin-top: 10%; margin-bottom: 10%;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_simple_negative.html
+++ b/tests/fixtures/block/block_margin_y_simple_negative.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_simple_negative_percentage_other.html
+++ b/tests/fixtures/block/block_margin_y_simple_negative_percentage_other.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: -10%; margin-bottom: -10%;"></div>
+  <div style="height: 10px; width: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_simple_negative_percentage_self.html
+++ b/tests/fixtures/block/block_margin_y_simple_negative_percentage_self.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: -10%; margin-bottom: -10%; width: 50px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_simple_positive.html
+++ b/tests/fixtures/block/block_margin_y_simple_positive.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: 10px; margin-bottom: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_simple_positive_percentage_other.html
+++ b/tests/fixtures/block/block_margin_y_simple_positive_percentage_other.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; margin-top: 10%; margin-bottom: 10%;"></div>
+  <div style="height: 10px; width: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_simple_positive_percentage_self.html
+++ b/tests/fixtures/block/block_margin_y_simple_positive_percentage_self.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="height: 10px; margin-top: 10%; margin-bottom: 10%; width: 50px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_total_collapse.html
+++ b/tests/fixtures/block/block_margin_y_total_collapse.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-top: 10px; margin-bottom: 10px;">
+    <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+    <div style="display: block; margin-top: 10px; margin-bottom: 10px;"></div>
+    <div style="display: block; height: 10px; margin-top: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_margin_y_total_collapse_complex.html
+++ b/tests/fixtures/block/block_margin_y_total_collapse_complex.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;">
+    <div style="height: 10px; margin-top: -5px; margin-bottom: -5px;"></div>
+    <div style="height: 10px; margin-top: 7px; margin-bottom: 3px;"></div>
+    <div style="height: 10px; margin-top: -6px; margin-bottom: 9px;"></div>
+  </div>
+  <div style="height: 10px; margin-top: -5px; margin-bottom: -5px;"></div>
+  <div style="height: 10px; margin-top: -10px; margin-bottom: -10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_overflow_scrollbars_overridden_by_available_space.html
+++ b/tests/fixtures/block/block_overflow_scrollbars_overridden_by_available_space.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: block; width: 2px; height: 4px;">
+  <div style="display: block; overflow: scroll;">
+    <div style="position: absolute; inset: 0px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_overflow_scrollbars_overridden_by_max_size.html
+++ b/tests/fixtures/block/block_overflow_scrollbars_overridden_by_max_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: block; overflow: scroll; max-width: 2px; max-height: 4px;">
+  <div style="position: absolute; inset: 0px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_overflow_scrollbars_overridden_by_size.html
+++ b/tests/fixtures/block/block_overflow_scrollbars_overridden_by_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: block; overflow: scroll; width: 2px; height: 4px;">
+  <div style="position: absolute; inset: 0px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_overflow_scrollbars_take_up_space_both_axis.html
+++ b/tests/fixtures/block/block_overflow_scrollbars_take_up_space_both_axis.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px; overflow: scroll;">
+  <div style="position: absolute; inset: 0px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_overflow_scrollbars_take_up_space_cross_axis.html
+++ b/tests/fixtures/block/block_overflow_scrollbars_take_up_space_cross_axis.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px; overflow-y: scroll;">
+  <div style="position: absolute; inset: 0px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_overflow_scrollbars_take_up_space_main_axis.html
+++ b/tests/fixtures/block/block_overflow_scrollbars_take_up_space_main_axis.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+<head/>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px; overflow-x: scroll;">
+  <div style="position: absolute; inset: 0px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_border_fixed_size.html
+++ b/tests/fixtures/block/block_padding_border_fixed_size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px; padding: 1px 3px 5px 7px; border-width: 2px 4px 6px 8px;">
+  <div style="height: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_border_intrinsic_size.html
+++ b/tests/fixtures/block/block_padding_border_intrinsic_size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; padding: 1px 3px 5px 7px; border-width: 2px 4px 6px 8px;">
+  <div style="height: 10px; width: 50px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_border_overrides_max_size.html
+++ b/tests/fixtures/block/block_padding_border_overrides_max_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; max-width: 12px; max-height: 12px; padding: 2px 4px 6px 8px; border-width: 1px 3px 5px 7px; border-style: solid; border-color: red;"><div></div></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_border_overrides_min_size.html
+++ b/tests/fixtures/block/block_padding_border_overrides_min_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; min-width: 0px; min-height: 0px; padding: 2px 4px 6px 8px; border-width: 1px 3px 5px 7px; border-style: solid; border-color: red;"><div></div></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_border_overrides_size.html
+++ b/tests/fixtures/block/block_padding_border_overrides_size.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; width: 12px; height: 12px; padding: 2px 4px 6px 8px; border-width: 1px 3px 5px 7px; border-style: solid; border-color: red;"><div></div></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_border_percentage_fixed_size.html
+++ b/tests/fixtures/block/block_padding_border_percentage_fixed_size.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px;">
+  <div style="display: block; padding: 1% 2% 3% 4%; border-width: 5% 6% 7% 8%;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_border_percentage_intrinsic_size.html
+++ b/tests/fixtures/block/block_padding_border_percentage_intrinsic_size.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; padding: 1% 2% 3% 4%; border-width: 5% 6% 7% 8%;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_fixed_size.html
+++ b/tests/fixtures/block/block_padding_fixed_size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px; padding: 2px 4px 6px 8px;">
+  <div style="height: 10px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_intrinsic_size.html
+++ b/tests/fixtures/block/block_padding_intrinsic_size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; padding: 2px 4px 6px 8px;">
+  <div style="height: 10px; width: 50px;"></div>
+  <div style="height: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_percentage_fixed_size.html
+++ b/tests/fixtures/block/block_padding_percentage_fixed_size.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px; height: 50px;">
+  <div style="display: block; padding: 1% 2% 3% 4%;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/block/block_padding_percentage_intrinsic_size.html
+++ b/tests/fixtures/block/block_padding_percentage_intrinsic_size.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block;">
+  <div style="display: block; padding: 1% 2% 3% 4%;">
+    <div style="display: block; height: 10px;"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockflex/blockflex_block_in_flex_column.html
+++ b/tests/fixtures/blockflex/blockflex_block_in_flex_column.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; flex-direction: column; width: 200px; height: 50px;">
+  <div style="display: block;"></div>
+  <div style="display: block; width: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockflex/blockflex_block_in_flex_row.html
+++ b/tests/fixtures/blockflex/blockflex_block_in_flex_row.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 200px; height: 50px;">
+  <div style="display: block;"></div>
+  <div style="display: block; width: 50px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockflex/blockflex_flex_in_block.html
+++ b/tests/fixtures/blockflex/blockflex_flex_in_block.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: flex;">
+    <div style="width: 50px; height: 50px;"></div>
+  </div>
+  <div style="display: block; width: 50px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockflex/blockflex_margin_y_collapse_through_blocked_by_flex.html
+++ b/tests/fixtures/blockflex/blockflex_margin_y_collapse_through_blocked_by_flex.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: flex; margin-top: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockflex/blockflex_margin_y_first_child_collapse_blocked_by_flex.html
+++ b/tests/fixtures/blockflex/blockflex_margin_y_first_child_collapse_blocked_by_flex.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: flex; margin-top: 10px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockflex/blockflex_margin_y_last_child_collapse_blocked_by_flex.html
+++ b/tests/fixtures/blockflex/blockflex_margin_y_last_child_collapse_blocked_by_flex.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: flex; margin-bottom: 10px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockflex/blockflex_overflow_hidden.html
+++ b/tests/fixtures/blockflex/blockflex_overflow_hidden.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: flex; width: 20px; height: 50px;">
+  <div style="display: block; flex-grow: 1; overflow: hidden;">HHHH&ZeroWidthSpace;HH</div>
+  <div style="display: block; flex-grow: 1;">HHHH&ZeroWidthSpace;HH</div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_auto.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_auto.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: auto;">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_fit_content_larger.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_fit_content_larger.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: fit-content(50px);">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_fit_content_middle.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_fit_content_middle.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: fit-content(30px);">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_fit_content_smaller.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_fit_content_smaller.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: fit-content(10px);">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_larger.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_larger.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 50px;">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_middle.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_middle.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 30px;">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_smaller.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_fixed_smaller.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 10px;">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_fr.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_fr.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: 1fr;">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_max_content.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_max_content.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: min-content;">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_block_in_grid_min_content.html
+++ b/tests/fixtures/blockgrid/blockgrid_block_in_grid_min_content.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: grid; grid-template-columns: min-content;">
+  <div style="display: block;">HH&ZeroWidthSpace;HH</div>
+  <div style="display: block;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_grid_in_block.html
+++ b/tests/fixtures/blockgrid/blockgrid_grid_in_block.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 200px;">
+  <div style="display: grid;">
+    <div style="width: 50px; height: 50px;"></div>
+  </div>
+  <div style="display: block; width: 50px; height: 20px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_margin_y_collapse_through_blocked_by_grid.html
+++ b/tests/fixtures/blockgrid/blockgrid_margin_y_collapse_through_blocked_by_grid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: block; height: 10px; margin-bottom: 10px;"></div>
+  <div style="display: grid; margin-top: 10px; margin-bottom: 10px;"></div>
+  <div style="display: block; height: 10px; margin-top: 10px;"></div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_margin_y_first_child_collapse_blocked_by_grid.html
+++ b/tests/fixtures/blockgrid/blockgrid_margin_y_first_child_collapse_blocked_by_grid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: grid; margin-top: 10px;">
+    <div style="display: block; margin-top: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/blockgrid/blockgrid_margin_y_last_child_collapse_blocked_by_grid.html
+++ b/tests/fixtures/blockgrid/blockgrid_margin_y_last_child_collapse_blocked_by_grid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="../base_style.css">
+  <title>
+    Test description
+  </title>
+</head>
+<body>
+
+<div id="test-root" style="display: block; width: 50px;">
+  <div style="display: grid; margin-bottom: 10px;">
+    <div style="display: block; margin-bottom: 10px;">
+      <div style="height: 10px;"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -48,7 +48,7 @@ Date        Failed      Passes      Remarks
 def get_fixtures(max_count: int = None) -> dict[str, list]:
     fixtures = []
     folders = [
-        # "tests/fixtures/grid/*.html",
+        # "tests/fixtures/block/*.html",
         "tests/fixtures/**/*.html",
     ]
     files = [
@@ -243,7 +243,7 @@ def apply_node_measure(node: Node, element: ElementTree.Element) -> Node:
         )
     else:
         writing_mode = WritingMode.HORIZONTAL
-    node.measure = lambda known_dims, available_space: measure_standard_text(
+    node.measure = lambda _self, known_dims, available_space: measure_standard_text(
         available_space,
         text,
         writing_mode,


### PR DESCRIPTION
Fixes #86.

measure function signature has been changed to correspond to an instance method rather than a static method, eg. node instance (`self`) is included.

Some tests related to CSS Block and overflow are failing, to be investigated.

