### PR TITLE
Use border and padding from Taffy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Install ChromeDriver
@@ -21,7 +21,7 @@ jobs:
         run: pytest --cov-report xml:reports/coverage.xml --cov=stretchable --junit-xml reports/pytest.xml --html=reports/pytest.html --self-contained-html tests/
         continue-on-error: true
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: reports/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ pyo3 = { version = "0.20.0", features = ["abi3-py38", "extension-module"] }
 dict_derive = "0.5.0"
 log = "0.4"
 pyo3-log = ">=0.9.0, <1.0"
-taffy = ">=0.5.1, <0.6"
+taffy = ">=0.5.2, <0.6"

--- a/run_fixture.py
+++ b/run_fixture.py
@@ -33,16 +33,9 @@ In this file, percentage margins are calculated as a percentage of the elements 
 """
 
 filepath = Path(
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/flex/percentage_moderate_complexity.html"
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/grid/grid_margins_percent_start.html"
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/grid/grid_max_content_single_item_span_2_gap_fixed.html"
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/flex/gap_percentage_row_gap_wrapping.html"
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/flex/percentage_padding_should_calculate_based_only_on_width.html"
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/taffy/max_height_overrides_height_on_root.html"
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/taffy/min_height_overrides_height_on_root.html"
-    # "/Users/kenneth/Code/Personal/Python/stretchable/tests/fixtures/taffy/undefined_height_with_min_max.html"
-    "/Users/kenneth/Code/Personal/stretchable/tests/fixtures/block/block_overflow_scrollbars_overridden_by_available_space.html"
-)
+    "./tests/fixtures/flex/percentage_padding_should_calculate_based_only_on_width.html"
+    # "./tests/fixtures/block/block_overflow_scrollbars_overridden_by_available_space.html"
+).resolve()
 
 # Get layout using taffy
 xml = get_xml(filepath)
@@ -54,7 +47,7 @@ print_layout(node)
 
 # Get layout using Chrome
 driver = webdriver.Chrome()
-driver.get("file://" + str(filepath))
+driver.get(f"file://{filepath}")
 driver.implicitly_wait(0.5)
 node_expected = driver.find_element(by=By.ID, value="test-root")
 print("*** EXPECTED ***")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,20 +756,59 @@ fn node_compute_layout_with_measure(taffy: usize, node: usize, available_space: 
 #[derive(FromPyObject, IntoPyObject)]
 pub struct PyLayout {
     order: i64,
-    left: f32,
-    top: f32,
-    width: f32,
-    height: f32,
+    location: Vec<f32>,
+    size: Vec<f32>,
+    content_size: Vec<f32>,
+    scrollbar_size: Vec<f32>,
+    border: Vec<f32>,
+    padding: Vec<f32>,
+    // margin: Vec<f32>,
 }
+
+trait FromPoint<T> {
+    fn from_point(value: taffy::geometry::Point<T>) -> Vec<T>;
+}
+
+impl<T> FromPoint<T> for Vec<T> {
+    fn from_point(value: taffy::geometry::Point<T>) -> Self {
+        vec![ value.x, value.y ]
+    }
+}
+
+
+trait FromSize<T> {
+    fn from_size(value: taffy::geometry::Size<T>) -> Vec<T>;
+}
+
+impl<T> FromSize<T> for Vec<T> {
+    fn from_size(value: taffy::geometry::Size<T>) -> Self {
+        vec![ value.width, value.height ]
+    }
+}
+
+
+trait FromRect<T> {
+    fn from_rect(value: taffy::geometry::Rect<T>) -> Vec<T>;
+}
+
+impl<T> FromRect<T> for Vec<T> {
+    fn from_rect(value: taffy::geometry::Rect<T>) -> Self {
+        vec![ value.top, value.right, value.bottom, value.left ]
+    }
+}
+
 
 impl From<Layout> for PyLayout {
     fn from(layout: Layout) -> Self {
         PyLayout {
             order: layout.order as i64,
-            left: layout.location.x,
-            top: layout.location.y,
-            width: layout.size.width,
-            height: layout.size.height,
+            location: Vec::from_point(layout.location),            
+            size: Vec::from_size(layout.size),            
+            content_size: Vec::from_size(layout.content_size),            
+            scrollbar_size: Vec::from_size(layout.scrollbar_size),
+            border: Vec::from_rect(layout.border),  
+            padding: Vec::from_rect(layout.padding),  
+            // margin: Vec::from_rect(layout.margin),  
         }
     }
 }

--- a/src/stretchable/node.py
+++ b/src/stretchable/node.py
@@ -700,7 +700,7 @@ class Node(list["Node"]):
         elif edge == Edge.MARGIN and Edge.MARGIN not in self._box:
             # Taffy does not provide margin box, calculate it
             box_parent = self._parent.get_box(Edge.BORDER) if self._parent else None
-            box = box._offset(self.style.margin, box_parent)
+            box = self.border_box._offset(self.style.margin, box_parent)
             self._box[Edge.MARGIN] = box
         else:
             box = self._box[edge]

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -29,6 +29,7 @@ H_HEIGHT: float = 10.0
 ZERO_WIDTH_SPACE: str = "\u200b"
 XML_REPLACE = (("&ZeroWidthSpace;", ZERO_WIDTH_SPACE),)
 USE_ROUNDING: bool = False
+NUM_DECIMALS: int = 0
 
 """
 DEBUGGING NOTES:
@@ -116,7 +117,7 @@ def test_html_fixtures(driver: webdriver.Chrome, filepath: Path):
         node,
         node_expected,
         filepath.stem,
-        num_decimals=0 if USE_ROUNDING else 1,
+        num_decimals=0 if USE_ROUNDING else NUM_DECIMALS,
     )
 
 


### PR DESCRIPTION
- Closes #95 (except for margin which is not - yet? - exposed by Taffy). 
- Reduces the number of failing test fixtures by ~15.
- Upgrades test workflow actions to avoid upcoming deprecations.