### PR TITLE
Update python compatibility tags to 3.11+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,12 @@ build-backend = "maturin"
 
 [project]
 name = "stretchable"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 keywords = ["flexbox", "grid", "block", "stretch", "css", "layout"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
As I tried to test-run module with older ubuntu releases in https://github.com/mortencombat/stretchable/issues/102#issuecomment-2409870959 , noticed following incompatibility with Ubuntu-22.x (and earlier):

```
 > [6/6] RUN _venv/bin/python -c 'import stretchable':                                                                                                          
0.353 Traceback (most recent call last):                                                                                                                        
0.353   File "<string>", line 1, in <module>                                                                                                                    
0.353   File "/test/_venv/lib/python3.10/site-packages/stretchable/__init__.py", line 11, in <module>                                                           
0.353     from .node import Box, Edge, Node
0.353   File "/test/_venv/lib/python3.10/site-packages/stretchable/node.py", line 5, in <module>
0.353     from enum import StrEnum, auto
0.353 ImportError: cannot import name 'StrEnum' from 'enum' (/usr/local/lib/python3.10/enum.py)
```

Afaict issue is due to enum.StrEnum available in python-3.11+ stdlib only:
https://docs.python.org/3/library/enum.html#enum.StrEnum

Simplest fix seem to be updating pyproject.toml tags to reflect reality, which is what this trivial PR does.

Alternative fixes might be to import a compatibility enum module from pypi somewhere, or to reimplement or not use StrEnum, if compatibility with older pythons is useful to maintain in newer module releases.

Thanks.