### PR TITLE
Pin maturin (v1.7.6) and rust dependencies

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -15,7 +15,23 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       publish: ${{ steps.get-version.outputs.publish }}
+      maturin_version: ${{ steps.get-maturin-version.outputs.version }}
     steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Get maturin version from pyproject.toml
+        id: get-maturin-version
+        shell: python
+        run: |
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+          maturin_req = next(req for req in data["build-system"]["requires"] if req.startswith("maturin"))
+          version = maturin_req.split(">=")[1] if ">=" in maturin_req else maturin_req.split("==")[1]
+          print(f"maturin_version={version}", file=open(os.environ["GITHUB_OUTPUT"], "a"))
       - name: Get version from tag
         id: get-version
         run: |
@@ -36,33 +52,11 @@ jobs:
     needs: prepare
     strategy:
       matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        target: [x86_64, aarch64]
         include:
-          # Windows builds
-          # - os: windows-latest
-          #   target: x86_64
-          #   arch: x64
           - os: windows-latest
-            target: aarch64
-            arch: x64
-          # - os: windows-latest
-          #   target: i686
-          #   arch: x86
-          
-          # macOS builds
-          # - os: macos-latest
-          #   target: x86_64
-          #   arch: x64
-          # - os: macos-latest
-          #   target: aarch64
-          #   arch: x64
-          
-          # Ubuntu builds
-          # - os: ubuntu-latest
-          #   target: x86_64
-          #   arch: x64
-          # - os: ubuntu-latest
-          #   target: aarch64
-          #   arch: x64
+            target: i686
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,12 +64,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-          architecture: ${{ matrix.arch }}
+          python-version: 3.13
+          architecture: ${{ matrix.target == 'i686' && 'x86' || 'x64' }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "maturin>=1.7.4,<2.0" build
+          pip install "maturin==${{ needs.prepare.outputs.maturin_version }}" build
       - name: Update Cargo.toml version
         if: needs.prepare.outputs.publish == 'true'
         env:
@@ -93,6 +87,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: ${{ needs.prepare.outputs.maturin_version }}
           target: ${{ matrix.target }}
           manylinux: auto
           args: --release --out dist -m Cargo.toml
@@ -103,6 +98,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         if: matrix.os == 'ubuntu-latest'
         with:
+          maturin-version: ${{ needs.prepare.outputs.maturin_version }}
           target: ${{ matrix.target }}-unknown-linux-musl
           manylinux: musllinux_1_2
           args: --release --out dist -m Cargo.toml
@@ -112,7 +108,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.arch }}
+          name: ${{ matrix.os }}-${{ matrix.target }}
           path: dist/
 
   publish:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -42,14 +42,20 @@ jobs:
           if [[ "${{ github.ref }}" =~ $pattern ]]
           then
             ver="${BASH_REMATCH[1]}"
-            pub="true"
+            if [[ -n "${BASH_REMATCH[2]}" ]]
+            then
+              pub="false"
+            else
+              pub="true"
+            fi
           else
             ver=""
             pub="false"
           fi
           echo "version=$ver" >> "$GITHUB_OUTPUT"
           echo "publish=$pub" >> "$GITHUB_OUTPUT"
-
+          echo "version=$ver"
+          echo "publish=$pub"
   build:
     name: Build packages
     needs: prepare

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -26,6 +26,7 @@ jobs:
         id: get-maturin-version
         shell: python
         run: |
+          import os
           import tomllib
           with open("pyproject.toml", "rb") as f:
               data = tomllib.load(f)

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -10,12 +10,12 @@ permissions:
 
 jobs:
   prepare:
-    name: Get release version
+    name: Get maturin version and release version
     runs-on: ubuntu-latest
     outputs:
+      maturin_version: ${{ steps.get-maturin-version.outputs.maturin_version }}
       version: ${{ steps.get-version.outputs.version }}
       publish: ${{ steps.get-version.outputs.publish }}
-      maturin_version: ${{ steps.get-maturin-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -32,8 +32,10 @@ jobs:
               data = tomllib.load(f)
           maturin_req = next(req for req in data["build-system"]["requires"] if req.startswith("maturin"))
           version = maturin_req.split(">=")[1] if ">=" in maturin_req else maturin_req.split("==")[1]
-          print(f"maturin_version={version}", file=open(os.environ["GITHUB_OUTPUT"], "a"))
-      - name: Get version from tag
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"maturin_version={version}\n")
+          print(f"Maturin version: {version}")
+      - name: Get stretchable version from tag
         id: get-version
         run: |
           pattern="^refs\/tags\/v([0-9]+\.[0-9]+\.[0-9]+(-(a|alpha|b|beta|dev)[0-9]+)?)$"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -54,8 +54,8 @@ jobs:
           fi
           echo "version=$ver" >> "$GITHUB_OUTPUT"
           echo "publish=$pub" >> "$GITHUB_OUTPUT"
-          echo "version=$ver"
-          echo "publish=$pub"
+          echo "Version: $ver"
+          echo "Publish: $pub"
   build:
     name: Build packages
     needs: prepare

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ name = "stretchable"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["abi3-py38", "extension-module", "gil-refs", "generate-import-lib"] }
-dict_derive = "0.6.0"
-log = ">=0.4,<0.5"
-pyo3-log = ">=0.9.0, <1.0"
+pyo3 = { version = "=0.22.6", features = ["abi3-py38", "extension-module", "gil-refs"] }
+dict_derive = "=0.6.0"
+log = "=0.4.25"
+pyo3-log = "=0.11.0"
 taffy = "=0.7.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.7.4,<2.0"]
+requires = ["maturin==1.7.6"]
 build-backend = "maturin"
 
 [project]
@@ -32,7 +32,7 @@ module-name = "stretchable.taffylib"
 
 [project.optional-dependencies]
 build = [
-    "maturin>=1.7.4,<2.0",
+    "maturin==1.7.6",
     "build",
     "twine",
 ]


### PR DESCRIPTION
Previously maturin was `>=1.7.4,<2.0`, but maturin v1.7.7+ causes issues with cross-compilation to `aarch64` on Windows.

Appears `pyo3` may need to be upgraded to v0.23+ along with maturin to v1.8.1+, but this causes other issues in the codebase (dict-derive v0.6 does not appear to support pyo3 v0.23+.